### PR TITLE
Fix the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,10 +97,6 @@ jobs:
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
-          # Pass a personal access token (using our `ct-release-bot` account) to be able to trigger other workflows
-          # https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
-          # https://github.community/t/action-does-not-trigger-another-on-push-tag-action/17148/8
-          token: ${{ secrets.GH_RELEASE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
@@ -129,20 +125,17 @@ jobs:
             //npm.pkg.github.com/:_authToken=$GH_RELEASE_TOKEN
           EOF
         env:
-          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          GH_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build packages
-        run: yarn build
-
-      - name: Create Release Pull Request
+      - name: Create Release Pull Request or Publish to GitHub packages
         uses: changesets/action@master
         with:
           commit: 'Update version and deploy packages'
           title: 'Update version and deploy packages'
-          publish: yarn changeset publish
-          version: yarn changeset version
+          publish: yarn release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
 
   build-and-deploy:
     name: Deploy Storybook

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:watch": "yarn test --watch -u",
     "gen:theme-typings": "chakra-cli tokens packages/theme/src/index.ts",
     "changeset": "changeset",
-    "release": "changeset publish",
+    "release": "yarn build && changeset publish",
     "component:add": "ts-node ./tools/create-component"
   },
   "lint-staged": {


### PR DESCRIPTION
This PR (hopefully) fixes the `Cannot publish over existing version` bug in the release workflow.