### PR TITLE
Store our packages at npmjs.org instead of GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,14 +119,6 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Creating .npmrc
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            //npm.pkg.github.com/:_authToken=$GH_RELEASE_TOKEN
-          EOF
-        env:
-          GH_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Create Release Pull Request or Publish to GitHub packages
         uses: changesets/action@master
         with:
@@ -135,7 +127,7 @@ jobs:
           publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   build-and-deploy:
     name: Deploy Storybook

--- a/.npmrc.example
+++ b/.npmrc.example
@@ -1,1 +1,0 @@
-@OWNER:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test:watch": "yarn test --watch -u",
     "gen:theme-typings": "chakra-cli tokens packages/theme/src/index.ts",
     "changeset": "changeset",
-    "release": "yarn build && changeset publish",
+    "prerelease": "yarn build",
+    "release": "changeset publish",
     "component:add": "ts-node ./tools/create-component"
   },
   "lint-staged": {

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -60,7 +60,6 @@
     "react": "^16.13.0 || ^17.0.0"
   },
   "publishConfig": {
-    "access": "public",
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   }
 }

--- a/packages/cards/package.json
+++ b/packages/cards/package.json
@@ -60,7 +60,6 @@
     "react": "^16.13.0 || ^17.0.0"
   },
   "publishConfig": {
-    "access": "public",
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   }
 }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -58,7 +58,6 @@
     "react": "^16.13.0 || ^17.0.0"
   },
   "publishConfig": {
-    "access": "public",
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -53,7 +53,6 @@
     "react": "^16.13.0 || ^17.0.0"
   },
   "publishConfig": {
-    "access": "public",
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   }
 }


### PR DESCRIPTION
This makes our work with ci/cd much easier and more pleasant.
