### PR TITLE
Rename `MenuButton` to `SettingsMenuButton`

### DIFF
--- a/.changeset/perfect-eyes-check.md
+++ b/.changeset/perfect-eyes-check.md
@@ -1,0 +1,7 @@
+---
+'@easyfeedback/buttons': patch
+'@easyfeedback/cards': patch
+'@easyfeedback/navigations': patch
+---
+
+Rename `MenuButton` to `SettingsMenuButton`

--- a/packages/buttons/src/SettingsMenuButton.tsx
+++ b/packages/buttons/src/SettingsMenuButton.tsx
@@ -11,7 +11,7 @@ import { IoEllipsisVertical } from 'react-icons/io5'
 
 import { MenuListItem } from './models/MenuListItem'
 
-export type MenuButtonProps = {
+export type SettingsMenuButtonProps = {
   /** The list of menu items. */
   menuItems: MenuListItem[]
   /** The color of the `IoEllipsisVertical` icon. */
@@ -26,7 +26,11 @@ export type MenuButtonProps = {
  *
  * This special `Menu` is set with the `IoEllipsisVertical` icon.
  */
-export const MenuButton = ({ color, fontSize = 'md', menuItems }: MenuButtonProps) => {
+export const SettingsMenuButton = ({
+  color,
+  fontSize = 'md',
+  menuItems,
+}: SettingsMenuButtonProps) => {
   return (
     <Menu>
       <ChakraMenuButton
@@ -36,7 +40,7 @@ export const MenuButton = ({ color, fontSize = 'md', menuItems }: MenuButtonProp
         variant="unstyled"
         color={color}
         fontSize={fontSize}
-        data-testid="MenuButton"
+        data-testid="SettingsMenuButton"
       />
 
       <MenuList>

--- a/packages/buttons/src/index.ts
+++ b/packages/buttons/src/index.ts
@@ -1,3 +1,3 @@
 export * from './IconButton'
-export * from './MenuButton'
+export * from './SettingsMenuButton'
 export * from './models/MenuListItem'

--- a/packages/buttons/stories/SettingsMenuButton.stories.tsx
+++ b/packages/buttons/stories/SettingsMenuButton.stories.tsx
@@ -7,11 +7,11 @@ import {
   IoTrashBinOutline,
 } from 'react-icons/io5'
 
-import { MenuButton, MenuButtonProps } from '../src/MenuButton'
+import { SettingsMenuButton, SettingsMenuButtonProps } from '../src/SettingsMenuButton'
 
 export default {
   title: 'Components/Buttons/MenuButton',
-  component: MenuButton,
+  component: SettingsMenuButton,
   args: {
     menuItems: [
       { icon: IoDuplicateOutline, title: 'Duplicate' },
@@ -23,6 +23,6 @@ export default {
   },
 } as Meta
 
-const Template: Story<MenuButtonProps> = (args) => <MenuButton {...args} />
+const Template: Story<SettingsMenuButtonProps> = (args) => <SettingsMenuButton {...args} />
 
 export const Default = Template.bind({})

--- a/packages/buttons/tests/SettingsMenuButton.test.tsx
+++ b/packages/buttons/tests/SettingsMenuButton.test.tsx
@@ -1,16 +1,16 @@
 import { render, testA11y } from '@easyfeedback/test-utils'
 import { IoDuplicateOutline, IoTrashBinOutline } from 'react-icons/io5'
 
-import { MenuButton } from '../src'
+import { SettingsMenuButton } from '../src'
 
 const mockMenuItems = [
   { icon: IoDuplicateOutline, title: 'Duplicate' },
   { icon: IoTrashBinOutline, title: 'Delete', color: 'red.500' },
 ]
 
-const component = <MenuButton menuItems={mockMenuItems} />
+const component = <SettingsMenuButton menuItems={mockMenuItems} />
 
-describe('MenuButton component', () => {
+describe('SettingsMenuButton component', () => {
   it('passes a11y test', async () => {
     await testA11y(component)
   })

--- a/packages/cards/src/TemplateCard.tsx
+++ b/packages/cards/src/TemplateCard.tsx
@@ -9,7 +9,7 @@ import {
   Text,
   theme,
 } from '@chakra-ui/react'
-import { MenuButton, MenuButtonProps } from '@easyfeedback/buttons'
+import { SettingsMenuButton, SettingsMenuButtonProps } from '@easyfeedback/buttons'
 import { IoStatsChartSharp } from 'react-icons/io5'
 
 import { StateDot, StateDotProps } from './utils/StateDot'
@@ -23,7 +23,7 @@ export type TemplateCardProps = {
   imageSrc: string
   /** The number of views. */
   views?: number
-} & Omit<MenuButtonProps, 'color'> &
+} & Omit<SettingsMenuButtonProps, 'color'> &
   StateDotProps
 
 const componentHeight = 250
@@ -64,7 +64,7 @@ export const TemplateCard = ({
       />
 
       <Box pos="absolute" top="1" title="options" right="1" zIndex={theme.zIndices.docked + 1}>
-        <MenuButton color="white" menuItems={menuItems} />
+        <SettingsMenuButton color="white" menuItems={menuItems} />
       </Box>
 
       <Box

--- a/packages/navigations/src/FolderNavigation/SingleFolder.tsx
+++ b/packages/navigations/src/FolderNavigation/SingleFolder.tsx
@@ -1,5 +1,5 @@
 import { Center, HStack, LinkBox, LinkOverlay, Spacer } from '@chakra-ui/layout'
-import { MenuButton } from '@easyfeedback/buttons'
+import { SettingsMenuButton } from '@easyfeedback/buttons'
 import { MenuListItem } from '@easyfeedback/buttons'
 import { MouseEventHandler, useEffect, useState } from 'react'
 import { IoSettings, IoTrashBinOutline } from 'react-icons/io5'
@@ -70,7 +70,7 @@ export const SingleFolder = ({ folder, onEditSettings, onDeleteFolder }: SingleF
 
         <Spacer />
 
-        <MenuButton
+        <SettingsMenuButton
           color={isShownMenuButton ? 'black' : 'transparent'}
           fontSize="lg"
           menuItems={menuItems}

--- a/packages/navigations/tests/SingleFolder.test.tsx
+++ b/packages/navigations/tests/SingleFolder.test.tsx
@@ -6,13 +6,15 @@ const mockDefaultProps: SingleFolderProps = {
   folder: { id: '1', numberOfItems: 10, title: 'My Surveys', href: '#' },
 }
 
+const component = <SingleFolder {...mockDefaultProps} />
+
 describe('SingleFolder component', () => {
   it('passes a11y test', async () => {
-    await testA11y(<SingleFolder {...mockDefaultProps} />)
+    await testA11y(component)
   })
 
   it('renders the circle with the number of items', () => {
-    const { getByTestId } = render(<SingleFolder {...mockDefaultProps} />)
+    const { getByTestId } = render(component)
     expect(getByTestId('circle')).toContainHTML('10')
   })
 
@@ -23,26 +25,26 @@ describe('SingleFolder component', () => {
     expect(getByTestId('circle')).toContainHTML('…')
   })
 
-  it('renders the `MenuButton` in transparent as default', () => {
-    const { getByTestId } = render(<SingleFolder {...mockDefaultProps} />)
-    expect(getByTestId('MenuButton')).toHaveStyleRule('color', 'transparent')
+  it('renders the `SettingsMenuButton` in transparent as default', () => {
+    const { getByTestId } = render(component)
+    expect(getByTestId('SettingsMenuButton')).toHaveStyleRule('color', 'transparent')
   })
 
-  it('renders the `MenuButton` in black at hovering', () => {
-    const { getByTestId } = render(<SingleFolder {...mockDefaultProps} />)
+  it('renders the `SettingsMenuButton` in black at hovering', () => {
+    const { getByTestId } = render(component)
     userEvent.hover(getByTestId('SingleFolder'))
-    expect(getByTestId('MenuButton')).toHaveStyleRule('color', 'black')
+    expect(getByTestId('SettingsMenuButton')).toHaveStyleRule('color', 'black')
   })
 
-  it('renders the `MenuButton` in transparent after hover and unhover', () => {
-    const { getByTestId } = render(<SingleFolder {...mockDefaultProps} />)
+  it('renders the `SettingsMenuButton` in transparent after hover and unhover', () => {
+    const { getByTestId } = render(component)
     const container = getByTestId('SingleFolder')
-    const menuButton = getByTestId('MenuButton')
+    const SettingsMenuButton = getByTestId('SettingsMenuButton')
 
     userEvent.hover(container)
-    expect(menuButton).toHaveStyleRule('color', 'black')
+    expect(SettingsMenuButton).toHaveStyleRule('color', 'black')
 
     userEvent.unhover(container)
-    expect(menuButton).toHaveStyleRule('color', 'transparent')
+    expect(SettingsMenuButton).toHaveStyleRule('color', 'transparent')
   })
 })


### PR DESCRIPTION
This change is to clarify what exactly the button does. Especially since the `AccountMenuButton` will be added soon this can avoid confusion.